### PR TITLE
`toString` now works with null keys or values

### DIFF
--- a/src/Dictionary.ts
+++ b/src/Dictionary.ts
@@ -211,7 +211,7 @@ export default class Dictionary<K, V>{
     toString(): string {
         let toret = "{";
         this.forEach((k, v) => {
-            toret = toret + "\n\t" + k.toString() + " : " + v.toString();
+            toret = toret + "\n\t" + (k === null ? k : k.toString()) + " : " + (v === null ? v : v.toString())
         });
         return toret + "\n}";
     }


### PR DESCRIPTION
Fixed exception 
TypeError: Cannot read property `toString` of null 
when calling toString and key or value is null.